### PR TITLE
Update @font-face declarations in CSS style sheets

### DIFF
--- a/webfonts/leaguegothic-condensed.css
+++ b/webfonts/leaguegothic-condensed.css
@@ -12,7 +12,7 @@
 @font-face {
   font-family: 'League Gothic Condensed';
   font-style: normal; /* Roman (Regular) */
-  src: url('leaguegothic-condensed-regular-webfont.eot'),
+  src: url('leaguegothic-condensed-regular-webfont.eot');
   src: url('leaguegothic-condensed-regular-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-condensed-regular-webfont.woff') format('woff'),
        url('leaguegothic-condensed-regular-webfont.ttf')  format('truetype'),
@@ -22,7 +22,7 @@
 @font-face {
   font-family: 'League Gothic Condensed';
   font-style: italic;
-  src: url('leaguegothic-condensed-italic-webfont.eot'),
+  src: url('leaguegothic-condensed-italic-webfont.eot');
   src: url('leaguegothic-condensed-italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-condensed-italic-webfont.woff') format('woff'),
        url('leaguegothic-condensed-italic-webfont.ttf')  format('truetype'),

--- a/webfonts/leaguegothic-condensed.css
+++ b/webfonts/leaguegothic-condensed.css
@@ -1,29 +1,3 @@
-/* Regular */
-@font-face {
-    font-family: 'League Gothic';
-    src: url('leaguegothic-regular-webfont.eot');
-    src: url('leaguegothic-regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('leaguegothic-regular-webfont.woff') format('woff'),
-         url('leaguegothic-regular-webfont.ttf') format('truetype'),
-         url('leaguegothic-regular-webfont.svg#league_gothicregular') format('svg');
-    font-weight: normal;
-    font-style: normal;
-
-}
-
-/* Italic */
-@font-face {
-    font-family: 'League Gothic';
-    src: url('leaguegothic-italic-webfont.eot');
-    src: url('leaguegothic-italic-webfont.eot?#iefix') format('embedded-opentype'),
-         url('leaguegothic-italic-webfont.woff') format('woff'),
-         url('leaguegothic-italic-webfont.ttf') format('truetype'),
-         url('leaguegothic-italic-webfont.svg#league_gothic_italicregular') format('svg');
-    font-weight: normal;
-    font-style: italic;
-
-}
-
 /* Condensed */
 @font-face {
     font-family: 'League Gothic Condensed';

--- a/webfonts/leaguegothic-condensed.css
+++ b/webfonts/leaguegothic-condensed.css
@@ -1,24 +1,28 @@
-/* Condensed */
-@font-face {
-    font-family: 'League Gothic Condensed';
-    src: url('leaguegothic-condensed-regular-webfont.eot');
-    src: url('leaguegothic-condensed-regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('leaguegothic-condensed-regular-webfont.woff') format('woff'),
-         url('leaguegothic-condensed-regular-webfont.ttf') format('truetype'),
-         url('leaguegothic-condensed-regular-webfont.svg#league_gothic_condensed-Rg') format('svg');
-    font-weight: normal;
-    font-style: normal;
+/*
+  'League Gothic Condensed'
+  https://www.theleagueofmoveabletype.com/league-gothic
 
+  Copyright (c) 2010, Caroline Hadilaksono & Micah Rich
+  <caroline@hadilaksono>, <micah@micahrich.com>,
+  with Reserved Font Name: "League Gothic".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'League Gothic Condensed';
+  font-style: normal; /* Roman (Regular) */
+  src: url('leaguegothic-condensed-regular-webfont.eot?#iefix') format('embedded-opentype'),
+       url('leaguegothic-condensed-regular-webfont.woff') format('woff'),
+       url('leaguegothic-condensed-regular-webfont.ttf')  format('truetype'),
+       url('leaguegothic-condensed-regular-webfont.svg#league_gothic_condensedRg') format('svg');
 }
 
-/* Condensed Italic */
 @font-face {
-    font-family: 'League Gothic Condensed';
-    src: url('leaguegothic-condensed-italic-webfont.eot');
-    src: url('leaguegothic-condensed-italic-webfont.eot?#iefix') format('embedded-opentype'),
-         url('leaguegothic-condensed-italic-webfont.woff') format('woff'),
-         url('leaguegothic-condensed-italic-webfont.ttf') format('truetype'),
-         url('leaguegothic-condensed-italic-webfont.svg#league_gothic_condensed_itaRg') format('svg');
-    font-weight: normal;
-    font-style: italic;
+  font-family: 'League Gothic Condensed';
+  font-style: italic;
+  src: url('leaguegothic-condensed-italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('leaguegothic-condensed-italic-webfont.woff') format('woff'),
+       url('leaguegothic-condensed-italic-webfont.ttf')  format('truetype'),
+       url('leaguegothic-condensed-italic-webfont.svg#league_gothic_condensed_itaRg') format('svg');
 }

--- a/webfonts/leaguegothic-condensed.css
+++ b/webfonts/leaguegothic-condensed.css
@@ -12,6 +12,7 @@
 @font-face {
   font-family: 'League Gothic Condensed';
   font-style: normal; /* Roman (Regular) */
+  src: url('leaguegothic-condensed-regular-webfont.eot'),
   src: url('leaguegothic-condensed-regular-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-condensed-regular-webfont.woff') format('woff'),
        url('leaguegothic-condensed-regular-webfont.ttf')  format('truetype'),
@@ -21,6 +22,7 @@
 @font-face {
   font-family: 'League Gothic Condensed';
   font-style: italic;
+  src: url('leaguegothic-condensed-italic-webfont.eot'),
   src: url('leaguegothic-condensed-italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-condensed-italic-webfont.woff') format('woff'),
        url('leaguegothic-condensed-italic-webfont.ttf')  format('truetype'),

--- a/webfonts/leaguegothic.css
+++ b/webfonts/leaguegothic.css
@@ -1,0 +1,25 @@
+/* Regular */
+@font-face {
+    font-family: 'League Gothic';
+    src: url('leaguegothic-regular-webfont.eot');
+    src: url('leaguegothic-regular-webfont.eot?#iefix') format('embedded-opentype'),
+         url('leaguegothic-regular-webfont.woff') format('woff'),
+         url('leaguegothic-regular-webfont.ttf') format('truetype'),
+         url('leaguegothic-regular-webfont.svg#league_gothicregular') format('svg');
+    font-weight: normal;
+    font-style: normal;
+
+}
+
+/* Italic */
+@font-face {
+    font-family: 'League Gothic';
+    src: url('leaguegothic-italic-webfont.eot');
+    src: url('leaguegothic-italic-webfont.eot?#iefix') format('embedded-opentype'),
+         url('leaguegothic-italic-webfont.woff') format('woff'),
+         url('leaguegothic-italic-webfont.ttf') format('truetype'),
+         url('leaguegothic-italic-webfont.svg#league_gothic_italicregular') format('svg');
+    font-weight: normal;
+    font-style: italic;
+
+}

--- a/webfonts/leaguegothic.css
+++ b/webfonts/leaguegothic.css
@@ -12,6 +12,7 @@
 @font-face {
   font-family: 'League Gothic';
   font-style: normal; /* Roman (Regular) */
+  src: url('leaguegothic-regular-webfont.eot'),
   src: url('leaguegothic-regular-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-regular-webfont.woff') format('woff'),
        url('leaguegothic-regular-webfont.ttf')  format('truetype'),
@@ -21,6 +22,7 @@
 @font-face {
   font-family: 'League Gothic';
   font-style: italic;
+  src: url('leaguegothic-italic-webfont.eot'),
   src: url('leaguegothic-italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-italic-webfont.woff') format('woff'),
        url('leaguegothic-italic-webfont.ttf')  format('truetype'),
@@ -37,6 +39,7 @@
   font-family: 'League Gothic';
   font-stretch: condensed;
   font-style: normal; /* Roman (Regular) */
+  src: url('leaguegothic-condensed-regular-webfont.eot'),
   src: url('leaguegothic-condensed-regular-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-condensed-regular-webfont.woff') format('woff'),
        url('leaguegothic-condensed-regular-webfont.ttf')  format('truetype'),
@@ -47,6 +50,7 @@
   font-family: 'League Gothic';
   font-stretch: condensed;
   font-style: italic;
+  src: url('leaguegothic-condensed-italic-webfont.eot'),
   src: url('leaguegothic-condensed-italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-condensed-italic-webfont.woff') format('woff'),
        url('leaguegothic-condensed-italic-webfont.ttf')  format('truetype'),

--- a/webfonts/leaguegothic.css
+++ b/webfonts/leaguegothic.css
@@ -12,7 +12,7 @@
 @font-face {
   font-family: 'League Gothic';
   font-style: normal; /* Roman (Regular) */
-  src: url('leaguegothic-regular-webfont.eot'),
+  src: url('leaguegothic-regular-webfont.eot');
   src: url('leaguegothic-regular-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-regular-webfont.woff') format('woff'),
        url('leaguegothic-regular-webfont.ttf')  format('truetype'),
@@ -22,7 +22,7 @@
 @font-face {
   font-family: 'League Gothic';
   font-style: italic;
-  src: url('leaguegothic-italic-webfont.eot'),
+  src: url('leaguegothic-italic-webfont.eot');
   src: url('leaguegothic-italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-italic-webfont.woff') format('woff'),
        url('leaguegothic-italic-webfont.ttf')  format('truetype'),
@@ -39,7 +39,7 @@
   font-family: 'League Gothic';
   font-stretch: condensed;
   font-style: normal; /* Roman (Regular) */
-  src: url('leaguegothic-condensed-regular-webfont.eot'),
+  src: url('leaguegothic-condensed-regular-webfont.eot');
   src: url('leaguegothic-condensed-regular-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-condensed-regular-webfont.woff') format('woff'),
        url('leaguegothic-condensed-regular-webfont.ttf')  format('truetype'),
@@ -50,7 +50,7 @@
   font-family: 'League Gothic';
   font-stretch: condensed;
   font-style: italic;
-  src: url('leaguegothic-condensed-italic-webfont.eot'),
+  src: url('leaguegothic-condensed-italic-webfont.eot');
   src: url('leaguegothic-condensed-italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('leaguegothic-condensed-italic-webfont.woff') format('woff'),
        url('leaguegothic-condensed-italic-webfont.ttf')  format('truetype'),

--- a/webfonts/leaguegothic.css
+++ b/webfonts/leaguegothic.css
@@ -1,25 +1,54 @@
-/* Regular */
-@font-face {
-    font-family: 'League Gothic';
-    src: url('leaguegothic-regular-webfont.eot');
-    src: url('leaguegothic-regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('leaguegothic-regular-webfont.woff') format('woff'),
-         url('leaguegothic-regular-webfont.ttf') format('truetype'),
-         url('leaguegothic-regular-webfont.svg#league_gothicregular') format('svg');
-    font-weight: normal;
-    font-style: normal;
+/*
+  'League Gothic'
+  https://www.theleagueofmoveabletype.com/league-gothic
 
+  Copyright (c) 2010, Caroline Hadilaksono & Micah Rich
+  <caroline@hadilaksono>, <micah@micahrich.com>,
+  with Reserved Font Name: "League Gothic".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'League Gothic';
+  font-style: normal; /* Roman (Regular) */
+  src: url('leaguegothic-regular-webfont.eot?#iefix') format('embedded-opentype'),
+       url('leaguegothic-regular-webfont.woff') format('woff'),
+       url('leaguegothic-regular-webfont.ttf')  format('truetype'),
+       url('leaguegothic-regular-webfont.svg#league_gothicregular') format('svg');
 }
 
-/* Italic */
 @font-face {
-    font-family: 'League Gothic';
-    src: url('leaguegothic-italic-webfont.eot');
-    src: url('leaguegothic-italic-webfont.eot?#iefix') format('embedded-opentype'),
-         url('leaguegothic-italic-webfont.woff') format('woff'),
-         url('leaguegothic-italic-webfont.ttf') format('truetype'),
-         url('leaguegothic-italic-webfont.svg#league_gothic_italicregular') format('svg');
-    font-weight: normal;
-    font-style: italic;
+  font-family: 'League Gothic';
+  font-style: italic;
+  src: url('leaguegothic-italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('leaguegothic-italic-webfont.woff') format('woff'),
+       url('leaguegothic-italic-webfont.ttf')  format('truetype'),
+       url('leaguegothic-italic-webfont.svg#league_gothic_italicregular') format('svg');
+}
 
+/*
+  Note: font-stretch support is currently EXPERIMENTAL in browsers (2013).
+  For cross-browser support, use the alternate family 'League Gothic Condensed'
+  defined in a separate style sheet.
+*/
+
+@font-face {
+  font-family: 'League Gothic';
+  font-stretch: condensed;
+  font-style: normal; /* Roman (Regular) */
+  src: url('leaguegothic-condensed-regular-webfont.eot?#iefix') format('embedded-opentype'),
+       url('leaguegothic-condensed-regular-webfont.woff') format('woff'),
+       url('leaguegothic-condensed-regular-webfont.ttf')  format('truetype'),
+       url('leaguegothic-condensed-regular-webfont.svg#league_gothic_condensedRg') format('svg');
+}
+
+@font-face {
+  font-family: 'League Gothic';
+  font-stretch: condensed;
+  font-style: italic;
+  src: url('leaguegothic-condensed-italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('leaguegothic-condensed-italic-webfont.woff') format('woff'),
+       url('leaguegothic-condensed-italic-webfont.ttf')  format('truetype'),
+       url('leaguegothic-condensed-italic-webfont.svg#league_gothic_condensed_itaRg') format('svg');
 }


### PR DESCRIPTION
The format used for the @font-face declarations is now
the "Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
