### PR TITLE
Update copyright status in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _by [Caroline Hadilaksono](https://www.hadilaksono.com/), [Micah Rich](https://m
 
 League Gothic is a revival of an old classic, and one of our favorite typefaces, Alternate Gothic #1.
 It was originally designed by [Morris Fuller Benton](https://en.wikipedia.org/wiki/Morris_Fuller_Benton) for the [American Type Founders](https://en.wikipedia.org/wiki/American_Type_Founders) Company in 1903.
-The company went bankrupt in 1993, and since the original typeface was created before 1923, the typeface is in the public domain.
+The company went bankrupt in 1993, and since the original typeface was created over 95 years ago, the typeface is in the public domain.
 
 We decided to make our own version, and contribute it to the Open Source Type Movement.
 Thanks to a commission from the fine & patient folks over at [WND.com](https://www.wnd.com/), it’s been revised & updated with contributions from Micah Rich, Tyler Finck, and [Dannci](https://twitter.com/dannci), who contributed extra glyphs.


### PR DESCRIPTION
The Copyright Term Extension Act extended copyrights by twenty years, to a maximum 95 years after publication. Since its passage in 1998, the only works whose copyrights expired were those published before 1923—until 2019, when the public domain “clock” started ticking again. Now the year of copyright extension changes every year (for instance, currently works published in *1925* and earlier are all in the public domain).

So, this updates the phrasing slightly.